### PR TITLE
Add Theme Discovery Section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ Options:
   -V, --version  Print version
 ```
 
-## Theme Discovery (XDG)
+## Theme Discovery
 
 Ferrisume discovers themes from (in order):
 
 - `./themes` in the current directory
 - XDG data dir: `${XDG_DATA_HOME:-$HOME/.local/share}/ferrisume/themes`
 - System dir (non-Windows): `/usr/share/ferrisume/themes`
+- macOS: `~/Library/Application Support/com.ferrisume.ferrisume/themes`
+- Windows: `%APPDATA%\ferrisume\ferrisume\data\themes`
 - Next to the executable: `<exe-dir>/themes`
 
 Quick setup on Linux (XDG):
@@ -61,7 +63,8 @@ RUST_LOG=info ferrisume themes
 
 Notes:
 
-- If no filesystem theme is found, the embedded default is extracted to a
-temporary directory (you may see a `/tmp/.../default` path in the list).
+- If no theme named `default` is found in the filesystem, the embedded default
+is extracted to a temporary directory (you may see a `/tmp/.../default` path in
+the list).
 - You can always reference a theme by path:
-`ferrisume export -t ./themes/<name> ...`.
+`ferrisume export -t /path/to/your/theme`.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,32 @@ Options:
   -h, --help     Print help
   -V, --version  Print version
 ```
+
+## Theme Discovery (XDG)
+
+Ferrisume discovers themes from (in order):
+
+- `./themes` in the current directory
+- XDG data dir: `${XDG_DATA_HOME:-$HOME/.local/share}/ferrisume/themes`
+- System dir (non-Windows): `/usr/share/ferrisume/themes`
+- Next to the executable: `<exe-dir>/themes`
+
+Quick setup on Linux (XDG):
+
+```bash
+mkdir -p "${XDG_DATA_HOME:-$HOME/.local/share}/ferrisume/themes/<your-theme>"
+# Place `config.toml` and `templates/` inside that directory
+```
+
+Verify discovery:
+
+```bash
+RUST_LOG=info ferrisume themes
+```
+
+Notes:
+
+- If no filesystem theme is found, the embedded default is extracted to a
+temporary directory (you may see a `/tmp/.../default` path in the list).
+- You can always reference a theme by path:
+`ferrisume export -t ./themes/<name> ...`.


### PR DESCRIPTION
This PR enhances the project documentation by introducing and refining a new section in the `README.md` that explains how Ferrisume discovers and loads themes across different operating systems. The added instructions improve user clarity around theme placement, default fallback behavior, and debugging tools, particularly for new users trying to configure or troubleshoot custom themes.

### Changes:

- Add initial "Theme Discovery" section to `README.md` (dc51960)
  - Introduced a new section to document where Ferrisume looks for themes across platforms (Linux, macOS, Windows).
  - Included a quick setup example for Linux users using the XDG data directory.

- Update and expand the "Theme Discovery" section with more detailed instructions (532e0d9)
  - Clarified fallback behavior when no `default` theme is found, including the use of temporary directories.
  - Added usage tips such as referencing themes by absolute path and enabling `RUST_LOG=info` for verification and debugging.