### PR TITLE
Fix missing default theme on fresh download

### DIFF
--- a/src/core/theme.rs
+++ b/src/core/theme.rs
@@ -156,9 +156,6 @@ impl ThemeManager {
         if !default_theme_found {
             info!("No default theme found in filesystem, registering embedded default theme");
             self.register_embedded_themes();
-        } else if !any_theme_found {
-            info!("No themes found in filesystem, registering embedded themes as fallback");
-            self.register_embedded_themes();
         }
 
         if self.themes.is_empty() {


### PR DESCRIPTION
The condition `else if !any_theme_found` in the theme discovery logic was unreachable because when `default_theme_found` is true (making the first condition false), `any_theme_found` is also always true (since finding the default theme sets both flags)